### PR TITLE
ci: updates deprecated actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ jobs:
     name: Tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d50f8ea76748df49594d9b109b614f3b4db63c71  # v3.0.0
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
         with:
           fetch-depth: 0
 
       - name: Bump version and push tag
-        uses: mathieudutour/github-tag-action@d745f2e74aaf1ee82e747b181f7a0967978abee0 # v6.0
+        uses: mathieudutour/github-tag-action@fcfbdceb3093f6d85a3b194740f8c6cec632f4e2 # v6.1
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -25,17 +25,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@d50f8ea76748df49594d9b109b614f3b4db63c71  # v3.0.0
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@a5865a93f26fcb9014b34e4be3fb246a9691a281 # v3.0.0
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: 1.17
 
       - name: Run GoReleaser release
-        uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b # v2.9.1
+        uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757 # v3.2.0
         with:
           distribution: goreleaser
           version: v1.7.0

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@d50f8ea76748df49594d9b109b614f3b4db63c71  # v3.0.0
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
 
       - name: Set up Go
-        uses: actions/setup-go@a5865a93f26fcb9014b34e4be3fb246a9691a281 # v3.0.0
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: 1.17
 
-      - uses: actions/cache@2d8d0d1c9b41812b6fd3d4ae064360e7d8762c7b # v3.0.0
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: |
             ~/.cache/go-build
@@ -25,13 +25,13 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run GoReleaser build snapshot
-        uses: goreleaser/goreleaser-action@0110a4acb73fda6a2c401b6d1cb70a11d5b0fadf # v2.9.1
+        uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757 # v3.2.0
         with:
           distribution: goreleaser
           version: v1.7.0
           args: build --snapshot --rm-dist
       - name: Archive snapshot binaries
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: snapshot-binaries
           path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@d50f8ea76748df49594d9b109b614f3b4db63c71  # v3.0.0
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
 
       - name: Set up Go
-        uses: actions/setup-go@a5865a93f26fcb9014b34e4be3fb246a9691a281 # v3.0.0
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: 1.17
 
-      - uses: actions/cache@2d8d0d1c9b41812b6fd3d4ae064360e7d8762c7b # v3.0.0
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: |
             ~/.cache/go-build
@@ -25,7 +25,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: lint
-        uses: magefile/mage-action@0a2bfd2ca891da3552ae39be755aecdce60ed1bc # v1.7.0
+        uses: magefile/mage-action@2c1951143e54356ebe6a0c6c971bae325b5b50f1 # v2.1.0
         with:
           version: latest
           args: build
@@ -36,14 +36,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@d50f8ea76748df49594d9b109b614f3b4db63c71  # v3.0.0
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
 
       - name: Set up Go
-        uses: actions/setup-go@a5865a93f26fcb9014b34e4be3fb246a9691a281 # v3.0.0
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: 1.17
 
-      - uses: actions/cache@2d8d0d1c9b41812b6fd3d4ae064360e7d8762c7b # v3.0.0
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: |
             ~/.cache/go-build
@@ -53,7 +53,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: lint
-        uses: magefile/mage-action@0a2bfd2ca891da3552ae39be755aecdce60ed1bc # v1.7.0
+        uses: magefile/mage-action@2c1951143e54356ebe6a0c6c971bae325b5b50f1 # v2.1.0
         with:
           version: latest
           args: lint
@@ -64,14 +64,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@d50f8ea76748df49594d9b109b614f3b4db63c71  # v3.0.0
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
 
       - name: Set up Go
-        uses: actions/setup-go@a5865a93f26fcb9014b34e4be3fb246a9691a281 # v3.0.0
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: 1.17
 
-      - uses: actions/cache@2d8d0d1c9b41812b6fd3d4ae064360e7d8762c7b # v3.0.0
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: |
             ~/.cache/go-build
@@ -81,7 +81,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: lint
-        uses: magefile/mage-action@0a2bfd2ca891da3552ae39be755aecdce60ed1bc # v1.7.0
+        uses: magefile/mage-action@2c1951143e54356ebe6a0c6c971bae325b5b50f1 # v2.1.0
         with:
           version: latest
           args: test


### PR DESCRIPTION
## Description
Updates deprecated actions that are not compliant with [this announcement from GitHub](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).